### PR TITLE
Add support of IPv6 addresses.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -827,6 +827,27 @@ func TestClient_parseURL(t *testing.T) {
 			expectedFile: "myfile",
 		},
 		{
+			name: "host and file IPv6",
+			url:  "[fc00::fe]/myfile",
+
+			expectedHost: "[fc00::fe]:69",
+			expectedFile: "myfile",
+		},
+		{
+			name: "host, port, and file IPv6",
+			url:  "[fc00::fe]:8345/myfile",
+
+			expectedHost: "[fc00::fe]:8345",
+			expectedFile: "myfile",
+		},
+		{
+			name: "scheme, host, port, and file IPv6",
+			url:  "tftp://[fc00::fe]:8345/myfile",
+
+			expectedHost: "[fc00::fe]:8345",
+			expectedFile: "myfile",
+		},
+		{
 			name: "port and file",
 			url:  ":8345/myfile",
 

--- a/conn.go
+++ b/conn.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	defaultPort       = 69
+	defaultPort       = "69"
 	defaultMode       = ModeOctet
 	defaultUDPNet     = "udp"
 	defaultTimeout    = time.Second


### PR DESCRIPTION
This commit updates parseURL to use the standard net/* libraries for
handling URLs. This has the side effect that hosts that are IPv6
addresses are handled correctly.

Signed-off-by: Luis Alberto Herrera <luisalberto@google.com>