### PR TITLE
Do not set conn.err on ACK receive timeout to fix sending files on po…

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -734,7 +734,6 @@ func (c *conn) getAck() stateType {
 	sAddr, err := c.readFromNet()
 	if err != nil {
 		c.log.trace("Error waiting for ACK: %v", err)
-		c.err = wrapError(err, "waiting for ACK")
 		return c.getAck
 	}
 


### PR DESCRIPTION
…or connections

This one fixes #2. There is no need to set conn.err in this line, as it is [written over](https://github.com/vcabbage/go-tftp/blob/07909dfbde3c4e388a7e353351191fbb987ce5a5/conn.go#L729) in the lilne above if the problem persists.